### PR TITLE
chore(devcontainer): add Codespaces skills bootstrap

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,18 @@
+# Devcontainer / Codespaces
+
+This repository uses an Astro site in `site/`.
+
+## What this devcontainer does
+
+- Uses Node.js **24.x**
+- Installs dependencies with `npm ci` in `site/` on creation/update
+- Starts the Astro dev server on attach: `npm run dev -- --host 0.0.0.0`
+- Forwards port **4321**
+
+## Local URL
+
+Because this site is configured for GitHub Pages Project Pages with `base: /urbanahighlandshoa`, the dev server content is under:
+
+- `http://localhost:4321/urbanahighlandshoa/`
+
+(The root `/` will 404.)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Urbana Highlands HOA",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "nodeGypDependencies": true
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "astro-build.astro-vscode",
+        "davidanson.vscode-markdownlint"
+      ],
+      "settings": {
+        "files.insertFinalNewline": true,
+        "files.trimTrailingWhitespace": true
+      }
+    }
+  },
+  "postCreateCommand": "bash -lc 'set -euo pipefail; cd site && npm ci; mkdir -p \"${containerWorkspaceFolder}/.copilot\"; if [ ! -d \"${containerWorkspaceFolder}/.copilot/skills/.git\" ]; then git clone https://github.com/aosama/skills \"${containerWorkspaceFolder}/.copilot/skills\"; else git -C \"${containerWorkspaceFolder}/.copilot/skills\" pull --ff-only; fi; mkdir -p \"$HOME/.copilot\"; ln -snf \"${containerWorkspaceFolder}/.copilot/skills\" \"$HOME/.copilot/skills\"; command -v copilot >/dev/null 2>&1 || npm i -g @github/copilot'",
+  "postAttachCommand": "cd site && npm run dev -- --host 0.0.0.0",
+  "forwardPorts": [4321],
+  "portsAttributes": {
+    "4321": {
+      "label": "Astro dev server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "remoteUser": "node",
+  "updateContentCommand": "bash -lc 'set -euo pipefail; cd site && npm ci; if [ -d \"${containerWorkspaceFolder}/.copilot/skills/.git\" ]; then git -C \"${containerWorkspaceFolder}/.copilot/skills\" pull --ff-only; fi'"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ site/.astro/
 link-check-results.json
 check-links.js
 
+# Copilot / Codespaces (do not commit cloned skills)
+.copilot/
+
 # Local verification screenshots
 # (Keep screenshots out of the repo; allow local, uncommitted captures.)
 docs/screenshots/


### PR DESCRIPTION
## Summary
Adds a devcontainer for Codespaces that:
- pins Node 24
- runs `npm ci` in `site/`
- clones `https://github.com/aosama/skills` into `${containerWorkspaceFolder}/.copilot/skills`
- symlinks it to `~/.copilot/skills`
- installs Copilot CLI (`npm i -g @github/copilot`) if missing

## Notes
- `.copilot/` is gitignored to avoid committing cloned skills.

## How to test
1. Create a new Codespace for this branch
2. Confirm repo has `.copilot/skills` cloned in workspace
3. Confirm `~/.copilot/skills` symlink exists
4. Run `copilot` then `/skills list` (and `/skills reload` if needed)
5. Dev server should be forwarded on port 4321
