### PR TITLE
fix(devcontainer): use verified Node 24 image tag

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Urbana Highlands HOA",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},

--- a/agents.md
+++ b/agents.md
@@ -68,6 +68,8 @@ When a PR changes the website, you must verify the deployed PR preview (not just
 
 **NEVER provide a URL or link to the user without first verifying it works.**
 
+**Never guess.** Do not make assumptions about versions, image tags, URLs, or environment behavior. Verify using authoritative sources (e.g., official registries/docs) or ask for clarification.
+
 Before sharing any URL (local dev server, PR preview, production site, external links):
 
 1. **Verify accessibility**: Use `curl -I <url>` to confirm HTTP 200, or open in Playwright/browser.


### PR DESCRIPTION
## What broke
Codespaces failed in recovery mode because the image tag `mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm` could not be found.

## Fix
- Switch devcontainer base image to the **verified** tag: `mcr.microsoft.com/devcontainers/javascript-node:24-bookworm`
- Added explicit **Never guess** guidance to `agents.md`

## Verification (authoritative)
Verified the tag exists via Microsoft Container Registry tags endpoint:
- `https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list` (look for `"24-bookworm"`)

## How to test
Create a new Codespace on this PR/branch; it should build the container normally (no recovery mode) and then run the existing postCreate steps (skills clone + Copilot CLI install).
