### PR TITLE
Harden workflow CI and preview automation

### DIFF
--- a/.github/actions/setup-site/action.yml
+++ b/.github/actions/setup-site/action.yml
@@ -1,0 +1,27 @@
+name: Setup site
+description: Set up Node.js and install dependencies for the Astro site
+
+inputs:
+  working-directory:
+    description: Path to the site directory
+    required: false
+    default: site
+  node-version:
+    description: Node.js version to install
+    required: false
+    default: "20"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: npm ci

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,7 @@ Build:
 
 - GitHub Pages deploy workflow: `.github/workflows/deploy.yml`
 - Hosted as GitHub Pages **Project Pages** under `/urbanahighlandshoa/`.
+- Production deploys are gated by the site build plus Playwright regression tests inside `.github/workflows/deploy.yml`.
 
 ## Branch policy
 
@@ -57,7 +58,7 @@ Build:
 - **Exception:** If the user explicitly instructs “commit and push to `main` (no PR)”, you may push directly to `main`.
   - If branch protections block the push, fall back to pushing a branch and open a PR.
 - Create a feature branch for your work (e.g., `feature/add-events-page`, `fix/header-nav`).
-- Open a PR, wait for the PR preview to deploy, verify your changes, then request review.
+- Open a PR, wait for the PR preview and regression checks to finish, verify your changes, then request review.
 - Only merge after approval (or self-merge if you're the sole maintainer and the build passes).
 
 ## Local tooling
@@ -100,6 +101,7 @@ When a PR changes the website, you must verify the deployed PR preview (not just
 - Navigate to the specific page(s) affected (example: `/documents/`), and confirm the change is visible and correct.
 - Before providing any web link (PR preview or production) to the user, verify it is actually accessible (e.g., open it in Playwright or `curl -I` and confirm it returns 200).
 - Include the PR preview URL(s) in your final response so the work is reviewable and referencable.
+- When a PR is merged, rely on the `main` deploy workflow for the final production publish; the preview cleanup workflow is only needed for closed, unmerged PRs.
 
 ## URL Verification (Critical)
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,15 +20,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install site dependencies
-        working-directory: site
-        env:
-          ASTRO_TELEMETRY_DISABLED: "1"
-        run: npm ci
+      - name: Set up site dependencies
+        uses: ./.github/actions/setup-site

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,29 +14,39 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  ASTRO_TELEMETRY_DISABLED: "1"
+
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: site/package-lock.json
+      - name: Set up site dependencies
+        uses: ./.github/actions/setup-site
 
-      - name: Install
-        working-directory: site
-        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
 
       - name: Build
-        working-directory: site
-        env:
-          ASTRO_TELEMETRY_DISABLED: "1"
         run: npm run build
+
+      - name: Run regression tests
+        run: npm test
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-deploy
+          path: site/playwright-report/
+          retention-days: 7
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -44,7 +54,7 @@ jobs:
           path: site/dist
 
   deploy:
-    needs: build
+    needs: verify
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -13,31 +13,26 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  ASTRO_TELEMETRY_DISABLED: "1"
+
 jobs:
   cleanup-pr-preview:
+    if: github.event.pull_request.merged != true
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install
-        working-directory: site
-        run: npm ci
+      - name: Set up site dependencies
+        uses: ./.github/actions/setup-site
 
       - name: Build (main)
         working-directory: site
         env:
-          ASTRO_TELEMETRY_DISABLED: "1"
           ASTRO_BASE: "/urbanahighlandshoa"
         run: npm run build
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,57 +15,50 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  ASTRO_TELEMETRY_DISABLED: "1"
+
 jobs:
   build-and-deploy-preview:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
-          path: main
 
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: pr
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Set up main site dependencies
+        uses: ./.github/actions/setup-site
         with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            main/site/package-lock.json
-            pr/site/package-lock.json
-
-      - name: Install (main)
-        working-directory: main/site
-        run: npm ci
+          working-directory: site
 
       - name: Build (main)
-        working-directory: main/site
+        working-directory: site
         env:
-          ASTRO_TELEMETRY_DISABLED: "1"
           ASTRO_BASE: "/urbanahighlandshoa"
         run: npm run build
 
-      - name: Install (PR)
-        working-directory: pr/site
-        run: npm ci
+      - name: Set up PR site dependencies
+        uses: ./.github/actions/setup-site
+        with:
+          working-directory: pr/site
 
       - name: Build (PR)
         working-directory: pr/site
         env:
-          ASTRO_TELEMETRY_DISABLED: "1"
           ASTRO_BASE: "/urbanahighlandshoa/__pr-preview__/pr-${{ github.event.number }}"
         run: npm run build
 
       - name: Assemble Pages artifact
         run: |
           mkdir -p combined
-          rsync -a main/site/dist/ combined/
+          rsync -a site/dist/ combined/
           mkdir -p combined/__pr-preview__/pr-${{ github.event.number }}/
           rsync -a pr/site/dist/ combined/__pr-preview__/pr-${{ github.event.number }}/
 
@@ -85,10 +78,28 @@ jobs:
           PREVIEW_URL: ${{ steps.deployment.outputs.page_url }}__pr-preview__/pr-${{ github.event.number }}/
         with:
           script: |
-            const body = `PR preview deployed: ${process.env.PREVIEW_URL}`;
-            await github.rest.issues.createComment({
+            const marker = '<!-- pr-preview-url -->';
+            const body = `${marker}\nPR preview deployed: ${process.env.PREVIEW_URL}`;
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body,
             });
+
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,10 +1,12 @@
 name: Regression Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+env:
+  ASTRO_TELEMETRY_DISABLED: "1"
 
 jobs:
   test:
@@ -16,17 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: site/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Set up site dependencies
+        uses: ./.github/actions/setup-site
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,11 @@
   "recommendations": [
     "astro-build.astro-vscode",
     "davidanson.vscode-markdownlint",
-    "maciejdems.add-to-gitignore"
+    "maciejdems.add-to-gitignore",
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+    "ms-edgedevtools.vscode-edge-devtools",
+    "vscode-icons-team.vscode-icons",
+    "tomoki1207.pdf",
+    "ms-vscode-remote.remote-wsl"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ npx playwright install chromium
 ## Deployment (GitHub Pages)
 
 The site automatically deploys to GitHub Pages when changes are pushed to the `main` branch.
+Before publishing, the deploy workflow rebuilds the site and reruns the Playwright regression suite so production deploys are gated on passing tests.
 
 ## Testing
 
-Regression tests run with **Playwright** (`cd site && npm test`) and are executed in CI via `.github/workflows/regression-tests.yml` on pushes and PRs to `main`.
+Regression tests run with **Playwright** (`cd site && npm test`) and are executed in CI via `.github/workflows/regression-tests.yml` for pull requests to `main`. The deploy workflow also reruns the same build-and-test checks on `main` before publishing to GitHub Pages.
 
 ### Deployment workflow
 
@@ -89,11 +90,12 @@ Regression tests run with **Playwright** (`cd site && npm test`) and are execute
 - **Trigger:** Push to `main` or manual workflow dispatch
 - **Process:**
   1. Checks out code
-  2. Sets up Node.js 20
-  3. Installs dependencies with `npm ci` in `site/`
+  2. Sets up Node.js 20 and installs `site/` dependencies
+  3. Installs Playwright Chromium
   4. Builds the site with `npm run build`
-  5. Uploads `site/dist/` as Pages artifact
-  6. Deploys to GitHub Pages
+  5. Runs `npm test`
+  6. Uploads `site/dist/` as Pages artifact
+  7. Deploys to GitHub Pages
 
 ### Configuration
 
@@ -111,7 +113,7 @@ PR previews are published automatically to a predictable URL:
 https://aosama.github.io/urbanahighlandshoa/__pr-preview__/pr-<PR_NUMBER>/
 ```
 
-The preview is deployed by `.github/workflows/pr-preview.yml` and (when permissions allow) the workflow will also comment the URL on the PR.
+The preview is deployed by `.github/workflows/pr-preview.yml` and (when permissions allow) the workflow keeps a single preview URL comment updated on the PR.
 
 ### Requirements
 
@@ -216,8 +218,8 @@ We welcome contributions to improve the website! Here's how you can help:
   ```
 
 - The preview is deployed by `.github/workflows/pr-preview.yml`
-- Review the preview before merging to ensure everything looks correct
-- Once merged to `main`, changes go live automatically
+- Review the preview and PR regression test results before merging to ensure everything looks correct
+- Once merged to `main`, the deploy workflow reruns the build and regression suite before changes go live
 
 ### Code style
 

--- a/docs/copilot-cloud-setup.md
+++ b/docs/copilot-cloud-setup.md
@@ -7,8 +7,9 @@ This repo is designed to work well with **GitHub Copilot coding agent** (the clo
 This repo includes:
 
 - `.github/workflows/copilot-setup-steps.yml`
+- `.github/actions/setup-site/action.yml`
 
-Copilot coding agent will run this workflow before it starts work (it installs Node and runs `npm ci` in `site/`).
+Copilot coding agent will run this workflow before it starts work. The workflow reuses the same shared site setup action as the CI workflows, so the agent gets the same Node.js and `npm ci` bootstrap behavior used elsewhere in the repo.
 
 Note: Astro CLI may attempt to send telemetry during builds; the repo disables it in CI to avoid Copilot firewall blocks.
 


### PR DESCRIPTION
## Summary

- gate GitHub Pages deploys on build plus Playwright regression tests
- reuse a shared setup action across workflow jobs
- reduce PR preview comment churn and skip cleanup for merged PRs
- align repo and Copilot docs with the revised workflow behavior

## Verification

- `cd site && npm run build`
- `cd site && npm test`
- `git --no-pager diff --check`
